### PR TITLE
Revert "Bump hexo-theme-next from 8.7.0 to 8.15.1"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "hexo-renderer-stylus": "^2.0.0",
         "hexo-server": "^2.0.0",
         "hexo-theme-landscape": "^0.0.3",
-        "hexo-theme-next": "^8.15.1"
+        "hexo-theme-next": "^8.7.0"
       }
     },
     "node_modules/a-sync-waterfall": {
@@ -904,9 +904,9 @@
       "integrity": "sha512-b0Di+TUVs4ESrNX4ULEh9uQmADpO6kr10rIJ2OGZM8suNQNFKdxn+vJUjnLfKkCPJAfVmS7/S83KCNYe4tpoNw=="
     },
     "node_modules/hexo-theme-next": {
-      "version": "8.15.1",
-      "resolved": "https://registry.npmjs.org/hexo-theme-next/-/hexo-theme-next-8.15.1.tgz",
-      "integrity": "sha512-ZM+dPx6mkFvmk8vp+dsvI+Cu1LE8XZW3PQjirmc+xd7CSUFby+4rYZ9puFVQlc5dvCM/lTfzp/WJu74JcC3Q2w=="
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/hexo-theme-next/-/hexo-theme-next-8.7.0.tgz",
+      "integrity": "sha512-lTrXk3kDBSy645iPImiPHieSIvZPzZDDbQZypD4O96ZlVIb9/PO9z7xzSNxROFm4LCyZMF2a8bJEuq5nVkxZRQ=="
     },
     "node_modules/hexo-util": {
       "version": "2.5.0",
@@ -2566,9 +2566,9 @@
       "integrity": "sha512-b0Di+TUVs4ESrNX4ULEh9uQmADpO6kr10rIJ2OGZM8suNQNFKdxn+vJUjnLfKkCPJAfVmS7/S83KCNYe4tpoNw=="
     },
     "hexo-theme-next": {
-      "version": "8.15.1",
-      "resolved": "https://registry.npmjs.org/hexo-theme-next/-/hexo-theme-next-8.15.1.tgz",
-      "integrity": "sha512-ZM+dPx6mkFvmk8vp+dsvI+Cu1LE8XZW3PQjirmc+xd7CSUFby+4rYZ9puFVQlc5dvCM/lTfzp/WJu74JcC3Q2w=="
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/hexo-theme-next/-/hexo-theme-next-8.7.0.tgz",
+      "integrity": "sha512-lTrXk3kDBSy645iPImiPHieSIvZPzZDDbQZypD4O96ZlVIb9/PO9z7xzSNxROFm4LCyZMF2a8bJEuq5nVkxZRQ=="
     },
     "hexo-util": {
       "version": "2.5.0",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,6 @@
     "hexo-renderer-stylus": "^2.0.0",
     "hexo-server": "^2.0.0",
     "hexo-theme-landscape": "^0.0.3",
-    "hexo-theme-next": "^8.15.1"
+    "hexo-theme-next": "^8.7.0"
   }
 }


### PR DESCRIPTION
Reverts rainchill/rainchill.github.io#34